### PR TITLE
1.12.2: Check for original LWJGL 3 class names as well

### DIFF
--- a/mod/1.12.2/forge-1.12.2/src/main/kotlin/top/fifthlight/touchcontroller/gal/PlatformWindowProviderImpl.kt
+++ b/mod/1.12.2/forge-1.12.2/src/main/kotlin/top/fifthlight/touchcontroller/gal/PlatformWindowProviderImpl.kt
@@ -10,9 +10,9 @@ object PlatformWindowProviderImpl : PlatformWindowProvider {
     private val logger = LoggerFactory.getLogger(PlatformWindowProviderImpl::class.java)
 
     override val windowWidth: Int
-        get() = Display.getWidth()
+        get() = (Display.getWidth() / Display.getPixelScaleFactor()).toInt()
     override val windowHeight: Int
-        get() = Display.getHeight()
+        get() = (Display.getHeight() / Display.getPixelScaleFactor()).toInt()
 
     private fun getCleanroomWindow(): Long? {
         val displayClass = runCatching {

--- a/mod/1.12.2/forge-1.12.2/src/main/kotlin/top/fifthlight/touchcontroller/gal/PlatformWindowProviderImpl.kt
+++ b/mod/1.12.2/forge-1.12.2/src/main/kotlin/top/fifthlight/touchcontroller/gal/PlatformWindowProviderImpl.kt
@@ -43,6 +43,8 @@ object PlatformWindowProviderImpl : PlatformWindowProvider {
 
             val glfwNativeClass = runCatching {
                 Class.forName("org.lwjgl3.glfw.GLFWNativeWin32")
+            }.getOrNull() ?: runCatching {
+                Class.forName("org.lwjgl.glfw.GLFWNativeWin32")
             }.getOrNull() ?: return null
             return glfwNativeClass.methods?.firstOrNull {
                 it.name == "glfwGetWin32Window"
@@ -73,6 +75,8 @@ object PlatformWindowProviderImpl : PlatformWindowProvider {
 
         val glfwNativeClass = runCatching {
             Class.forName("org.lwjgl3.glfw.GLFWNativeWayland")
+        }.getOrNull() ?: runCatching {
+            Class.forName("org.lwjgl.glfw.GLFWNativeWayland")
         }.getOrNull() ?: return null
         val displayPointer = glfwNativeClass.methods?.firstOrNull {
             it.name == "glfwGetWaylandDisplay"


### PR DESCRIPTION
This project keeps original LWJGL 3 namespace as `org.lwjgl.` and acts as a sort of "addon" to bridge LWJGL 2 API.
https://github.com/MCPHackers/legacy-lwjgl3

This commit adds an attempt to get `Class.forName`, but using original names such as `org.lwjgl.glfw.GLFWNativeWin32` or `org.lwjgl.glfw.GLFWNativeWayland`

For OSes with desktop scale, real window size is determined as `getWidth/getPixelScaleFactor`

Closes #299